### PR TITLE
File support

### DIFF
--- a/lib/elasticemail.rb
+++ b/lib/elasticemail.rb
@@ -19,6 +19,12 @@ require "elasticemail/attachment/remove_attachment"
 require "elasticemail/attachment/get_attachment"
 require "elasticemail/attachments"
 
+# Files
+require "elasticemail/file/upload"
+require "elasticemail/file/delete_file"
+require "elasticemail/file/load_file"
+require "elasticemail/files"
+
 # Contact
 require "elasticemail/contact/add_contact"
 require "elasticemail/contact/change_status_contact"

--- a/lib/elasticemail/file/delete_file.rb
+++ b/lib/elasticemail/file/delete_file.rb
@@ -1,0 +1,22 @@
+module Elasticemail
+  module ElasticFile
+    REMOVE_FILE_ATTRIBUTES_MAPPING = {
+      :api_key   => "apikey",
+      :file_name => "filename",
+      :file_id   => "userFileID",
+    }.freeze
+
+    # http://api.elasticemail.com/public/help#File_Delete
+    class DeleteFile < Struct.new(*REMOVE_FILE_ATTRIBUTES_MAPPING.keys)
+      include Elasticemail::Base
+
+      def path
+        :"/file/delete"
+      end
+
+      def mapping
+        REMOVE_FILE_ATTRIBUTES_MAPPING
+      end
+    end
+  end
+end

--- a/lib/elasticemail/file/load_file.rb
+++ b/lib/elasticemail/file/load_file.rb
@@ -1,0 +1,21 @@
+module Elasticemail
+  module ElasticFile
+    GET_FILE_ATTRIBUTES_MAPPING = {
+      :api_key       => "apikey",
+      :file_name     => "filename"
+    }.freeze
+
+    # http://api.elasticemail.com/public/help#File_Load
+    class LoadFile < Struct.new(*GET_FILE_ATTRIBUTES_MAPPING.keys)
+      include Elasticemail::Base
+
+      def path
+        :"/file/load"
+      end
+
+      def mapping
+        GET_FILE_ATTRIBUTES_MAPPING
+      end
+    end
+  end
+end

--- a/lib/elasticemail/file/upload.rb
+++ b/lib/elasticemail/file/upload.rb
@@ -1,0 +1,42 @@
+module Elasticemail
+  module Attachment
+    UPLOAD_ATTRIBUTES_MAPPING = {
+      :api_key            => "apikey",
+      :expires_after_days => "expiresAfterDays",
+      :file_name          => "name",
+    }.freeze
+
+    # http://api.elasticemail.com/public/help#File_Upload
+    class Upload < Struct.new(*UPLOAD_ATTRIBUTES_MAPPING.keys)
+      include Elasticemail::Base
+
+      attr_accessor :file_path, :file_content_type
+
+      def perform
+        super do
+          session.post do |request|
+            request.path   = [version, path].join('/')
+            request.params = {
+                                "apikey"           => api_key || _api_key,
+                                "expiresAfterDays" => expires_after_days || 30,
+                                "name"             => file_name,
+                             }
+            request.body   = { "file" => file }
+          end
+        end
+      end
+
+      def file
+        Faraday::UploadIO.new(file_path, file_content_type)
+      end
+
+      def path
+        :"/file/upload"
+      end
+
+      def mapping
+        UPLOAD_ATTRIBUTES_MAPPING
+      end
+    end
+  end
+end

--- a/lib/elasticemail/files.rb
+++ b/lib/elasticemail/files.rb
@@ -1,0 +1,21 @@
+module Elasticemail
+  class Files
+    def self.upload
+      file = ElasticFile::Upload.new
+      yield file
+      file.perform
+    end
+
+    def self.remove(file_name, api_key=nil)
+      attachment = ElasticFile::DeleteFile.new(api_key, file_name)
+      yield attachment if block_given?
+      attachment.perform
+    end
+
+    def self.load(file_name, attachment_id, api_key=nil)
+      attachment = ElasticFile::LoadFile.new(api_key, file_name, attachment_id)
+      yield attachment if block_given?
+      attachment.perform
+    end
+  end
+end

--- a/lib/elasticemail/files.rb
+++ b/lib/elasticemail/files.rb
@@ -13,7 +13,7 @@ module Elasticemail
     end
 
     def self.load(file_name, attachment_id, api_key=nil)
-      attachment = ElasticFile::LoadFile.new(api_key, file_name, attachment_id)
+      attachment = ElasticFile::LoadFile.new(api_key, file_name)
       yield attachment if block_given?
       attachment.perform
     end


### PR DESCRIPTION
ElasticEmail suddenly deprecated their Attachment endpoints and replaced them with File ones instead.

NOTE: Our testing account was closed by them because apparently having 2 accounts is against their terms, despite not having a sandbox for testing if using a single account.